### PR TITLE
Namespaced migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.project
 /.idea/
 /composer.lock
+/composer.phar
 /vendor/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or add
 
 to the ```require``` section of your `composer.json` file.
 
-Migrations are available from [migrations](./migrations).
+Migrations are available from [migrations](./migrations) folder.
 
 To add migrations to your application, edit the console config file to configure
 [a namespaced migration](http://www.yiiframework.com/doc-2.0/guide-db-migrations.html#namespaced-migrations):

--- a/README.md
+++ b/README.md
@@ -24,9 +24,29 @@ or add
 
 to the ```require``` section of your `composer.json` file.
 
-To create database tables run migration command
+Migrations are available from [migrations](./migrations).
+
+To add migrations to your application, edit the console config file to configure
+[a namespaced migration](http://www.yiiframework.com/doc-2.0/guide-db-migrations.html#namespaced-migrations):
+
+```php
+'controllerMap' => [
+    // ...
+    'migrate' => [
+        'class' => 'yii\console\controllers\MigrateController',
+        'migrationPath' => null,
+        'migrationNamespaces' => [
+            // ...
+            'conquer\oauth2\migrations',
+        ],
+    ],
+],
 ```
-$ yii migrate --migrationPath=@conquer/oauth2/migrations
+
+Then issue the `migrate/up` command:
+
+```sh
+yii migrate/up
 ```
 
 ## Usage

--- a/migrations/m150610_162817_oauth.php
+++ b/migrations/m150610_162817_oauth.php
@@ -5,6 +5,8 @@
  * @license https://github.com/borodulin/yii2-oauth2-server/blob/master/LICENSE
  */
 
+namespace conquer\oauth2\migrations;
+
 use yii\db\Schema;
 use yii\db\Migration;
 


### PR DESCRIPTION
Updated README.md with proper way of applying third party component migrations. This way `migrate/down` will work without need to specify path to migration file