### PR TITLE
Ability to specify scopes on TokenAuth filter

### DIFF
--- a/TokenAuth.php
+++ b/TokenAuth.php
@@ -68,7 +68,7 @@ class TokenAuth extends AuthMethod
         $accessToken = $this->getAccessToken();
 
         if (!$this->checkScopes($this->scopes, $accessToken->scope)) {
-            throw new UnauthorizedHttpException;
+            throw new UnauthorizedHttpException('The access token does not have required scopes.');
         }
 
         /** @var IdentityInterface $identityClass */


### PR DESCRIPTION
If no scopes specified then it works as usual. Useful for limiting access on specific actions in API applications.

```
public function behaviors()
{
    return [
        'tokenAuth' => [
            'class' => \conquer\oauth2\TokenAuth::class,
            'scopes' => 'scope1 scope2',
        ],
    ];
}
```