### PR TITLE
Remove refresh token from client credentials response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
     - php vendor/bin/codecept run --coverage --coverage-xml
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.0-dev"
+            "dev-master": "1.7.x-dev"
         }
     },
     "repositories": [

--- a/src/granttypes/ClientCredentials.php
+++ b/src/granttypes/ClientCredentials.php
@@ -9,7 +9,6 @@ namespace conquer\oauth2\granttypes;
 
 use conquer\oauth2\BaseModel;
 use conquer\oauth2\models\AccessToken;
-use conquer\oauth2\models\RefreshToken;
 
 /**
  * @author Andrey Borodulin
@@ -65,18 +64,11 @@ class ClientCredentials extends BaseModel
             'scope' => $this->scope,
         ]);
 
-        $refreshToken = RefreshToken::createRefreshToken([
-            'client_id' => $this->client_id,
-            'expires' => $this->refreshTokenLifetime + time(),
-            'scope' => $this->scope,
-        ]);
-
         return [
             'access_token' => $accessToken->access_token,
             'expires_in' => $this->accessTokenLifetime,
             'token_type' => $this->tokenType,
             'scope' => $this->scope,
-            'refresh_token' => $refreshToken->refresh_token,
         ];
     }
 }


### PR DESCRIPTION
Refresh token not needed in client credentials flow because there is no any confirmation from user. When access_token is expired new access_token can be requested again

https://oauth2.thephpleague.com/authorization-server/client-credentials-grant/